### PR TITLE
Update README and don't require global installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # galaxy-docs
 
 ## Run HEXO Server
-1. Navigate to your `galaxy-docs` directory and type `npm install -g hexo-cli`
-2. Navigate to `/site` and type `npm install`
-3. While still in `/site` type `hexo server`
+To run:
+
+```
+git submodule init
+git submodule update
+cd site
+npm install
+npm start
+```

--- a/site/package.json
+++ b/site/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.2.0"
+    "version": "3.2.2"
   },
   "dependencies": {
     "hexo": "^3.1.0",
@@ -22,6 +22,7 @@
     "hexo-s3-deploy": "^1.0.1"
   },
   "scripts": {
-    "deploy": "hexo-s3-deploy"
+    "deploy": "hexo-s3-deploy",
+    "start": "hexo serve"
   }
 }


### PR DESCRIPTION
- Add documentation of git submodule
- Don't require globally installed hexo-cli

This is now identical to apollo-docs (except for needing to go into the
site subdirectory)