### PR TITLE
Updated the support language.

### DIFF
--- a/content/support.md
+++ b/content/support.md
@@ -4,13 +4,13 @@ order: 12
 description: Learn about support options available in Galaxy
 ---
 
-All Galaxy customers can submit support cases from within Galaxy and receive Basic online support for deployment-related questions. There is no guaranteed response SLA for Basic support but questions are typically answered within 1-2 business days.  
+All Galaxy customers can submit support cases from within Galaxy and receive a 1 business day Support SLA for non-critical tickets.
+
+You can submit tickets to Galaxy support at [galaxy.meteor.com/support](https://galaxy.meteor.com/support) You can also access the ticketing page from the left-hand dropdown menu within your Galaxy account.
 
 Galaxy support is dedicated to resolving Galaxy-specific issues and troubleshooting cases where Galaxy's performance may be at fault. While we strive for "best effort" with regard to questions pertaining to Meteor, they are not an officially supported Galaxy subject area. 
 
-If you would like expert assistance with your Meteor question, consider a subscription to Galaxy Developer Support. You are also welcome to post your issue to the forums or to GitHub, depending on the situation.
-
-You can submit tickets to Galaxy support at [galaxy.meteor.com/support](https://galaxy.meteor.com/support)
+If you would like expert assistance with your Meteor question, consider a subscription to Meteor Developer Support, described below. 
 
 <h3 id="Enhanced Galaxy Support Options">Enhanced Galaxy Support Options</h3>
 

--- a/content/support.md
+++ b/content/support.md
@@ -6,7 +6,11 @@ description: Learn about support options available in Galaxy
 
 All Galaxy customers can submit support cases from within Galaxy and receive Basic online support for deployment-related questions. There is no guaranteed response SLA for Basic support but questions are typically answered within 1-2 business days.  
 
-You can submit tickets on [galaxy.meteor.com/support](https://galaxy.meteor.com/support)
+Galaxy support is dedicated to resolving Galaxy-specific issues and troubleshooting cases where Galaxy's performance may be at fault. While we strive for "best effort" with regard to questions pertaining to Meteor, they are not an officially supported Galaxy subject area. 
+
+If you would like expert assistance with your Meteor question, consider a subscription to Galaxy Developer Support. You are also welcome to post your issue to the forums or to GitHub, depending on the situation.
+
+You can submit tickets to Galaxy support at [galaxy.meteor.com/support](https://galaxy.meteor.com/support)
 
 <h3 id="Enhanced Galaxy Support Options">Enhanced Galaxy Support Options</h3>
 


### PR DESCRIPTION
Explaining that Galaxy's support focus is Galaxy and not Meteor, and if Meteor is your focus, consider devsub, or the forums or relevant GitHub pages.