### PR TITLE
Added > to indicate transfer instructions work for Meteor > 1.3

### DIFF
--- a/content/transfer-apps.md
+++ b/content/transfer-apps.md
@@ -12,7 +12,7 @@ You can deploy an application to one Galaxy account at a time. Galaxy utilizes t
 
 If you are a member of two or more accounts, you can then transfer the application to a different account.
 
-<h2 id="meteor-13">Transfer with Meteor 1.3 or high versions</h2>
+<h2 id="meteor-13">Transfer with Meteor 1.3 or higher versions</h2>
 
 To transfer the application, on the command line, type:
 `DEPLOY_HOSTNAME=galaxy.meteor.com meteor authorized [your_existing_hostname] --transfer [new_account_name]`

--- a/content/transfer-apps.md
+++ b/content/transfer-apps.md
@@ -12,12 +12,12 @@ You can deploy an application to one Galaxy account at a time. Galaxy utilizes t
 
 If you are a member of two or more accounts, you can then transfer the application to a different account.
 
-<h2 id="meteor-13">Transfer with Meteor > 1.3</h2>
+<h2 id="meteor-13">Transfer with Meteor 1.3 or high versions</h2>
 
 To transfer the application, on the command line, type:
 `DEPLOY_HOSTNAME=galaxy.meteor.com meteor authorized [your_existing_hostname] --transfer [new_account_name]`
 
-<h2 id="meteor-12">Transfer with Meteor < 1.2</h2>
+<h2 id="meteor-12">Transfer with Meteor 1.2 or lower versions</h2>
 
 To transfer the application, on the command line, type:
 `DEPLOY_HOSTNAME=galaxy.meteor.com meteor authorized [your_existing_hostname] --add [new_account_name]`

--- a/content/transfer-apps.md
+++ b/content/transfer-apps.md
@@ -12,7 +12,7 @@ You can deploy an application to one Galaxy account at a time. Galaxy utilizes t
 
 If you are a member of two or more accounts, you can then transfer the application to a different account.
 
-<h2 id="meteor-13">Transfer with Meteor 1.3</h2>
+<h2 id="meteor-13">Transfer with Meteor > 1.3</h2>
 
 To transfer the application, on the command line, type:
 `DEPLOY_HOSTNAME=galaxy.meteor.com meteor authorized [your_existing_hostname] --transfer [new_account_name]`


### PR DESCRIPTION
Rebased to master (you can delete update...1.3 branch, which wasn't) and made the > 1.3 change so doc is no longer outdated now that we're on Meteor 1.4.
