### PR TITLE
Document the container environment, custom base images, healthchecking, and the behavior of the default base image

### DIFF
--- a/content/base-image-packages.md
+++ b/content/base-image-packages.md
@@ -1,17 +1,30 @@
 ---
-title: Base image
+title: Default base image
 order: 16
-description: Learn which packages are on the Galaxy base image
+description: Learn about the default Galaxy base image
 ---
 
-The Galaxy base image runs Ubuntu 14.04 and comes with a set of packages pre-installed. Please note that package versions are not frozen and may be updated at any time.
+Most Galaxy users run their app with the default base image.  (For full control over the system libraries available to your app and its precise runtime environment, you can create a [custom base image](/custom-base-images.html) instead.)
 
+A base image is a [Docker](https://www.docker.com/) image.  The default base image is stored in the repository [`meteor/galaxy-app`](https://hub.docker.com/r/meteor/galaxy-app/) on Docker Hub and is itself based on the repository [`meteor/ubuntu`](https://hub.docker.com/r/meteor/ubuntu/).  The source for these packages can be found in the [`galaxy-images` GitHub repository](https://github.com/meteor/galaxy-images).
+
+<h2 id="packages">Installed packages</h2>
+
+The current Galaxy default base image runs Ubuntu 14.04 LTS and comes with a set of packages pre-installed. Please note that package versions are not frozen and may be updated at any time.
+
+Now that [custom base images](/custom-base-images.html) are available, we may remove some of these packages from the default base image, with appropriate warning.  While it's convenient to have these packages available, users don't have precise control over their versions; custom base images are a more powerful mechanism for installing packages like these ones.
+
+Packages useful as part of the build process:
 - [build-essential](http://packages.ubuntu.com/trusty/build-essential)
-- [wget](http://packages.ubuntu.com/trusty/wget)
 - [curl](http://packages.ubuntu.com/trusty/amd64/curl)
+- [wget](http://packages.ubuntu.com/trusty/wget)
 - [rsync](http://packages.ubuntu.com/trusty/rsync)
-- [phantomjs](http://packages.ubuntu.com/trusty/phantomjs)
+- [git](http://packages.ubuntu.com/trusty/git)
+- [xz-utils](http://packages.ubuntu.com/trusty/xz-utils)
 - [ca-certificates](http://packages.ubuntu.com/trusty/ca-certificates)
+
+Packages useful for popular npm packages (primarily image rendering):
+- [phantomjs](http://packages.ubuntu.com/trusty/phantomjs)
 - [imagemagick](http://packages.ubuntu.com/trusty/imagemagick)
 - [graphicsmagick](http://packages.ubuntu.com/trusty/graphicsmagick-dbg)
 - [libcairo2-dev](http://packages.ubuntu.com/trusty/libcairo2-dev)
@@ -22,6 +35,31 @@ The Galaxy base image runs Ubuntu 14.04 and comes with a set of packages pre-ins
 - [xfonts-base](http://packages.ubuntu.com/trusty/xfonts-base)
 - [xfonts-75dpi](http://packages.ubuntu.com/trusty/xfonts-75dpi)
 - [libpoppler-qt4-dev](http://packages.ubuntu.com/trusty/libpoppler-qt4-dev)
-- [git](http://packages.ubuntu.com/trusty/git)
 
-When Galaxy builds your deployed app into a Docker container, it installs the same version of Node used by the version of the `meteor` command-line tool that you used to deploy it.  (Currently, this uses the official binary distribution of Node from nodejs.org, not the Ubuntu package. It is installed into a non-standard directory which is prepended to the `$PATH` that your app sees.)
+In addition, the default base image contains several popular versions of Node preinstalled in directories with names like `/node-v8.9.3-linux-x64`. (Including these versions makes the container build and start process more efficient.)  Galaxy uses the official binary distribution of Node from nodejs.org, not the Ubuntu package.
+
+<h2 id="build">Build time behavior</h2>
+
+When you run `meteor deploy`, your local `meteor` command-line tool builds your app, bundles it into a [tarball](https://en.wikipedia.org/wiki/Tar_(computing%29), and uploads it to Galaxy.  Galaxy then builds a Docker image for your app based on the default base image by running the `/app/setup.sh` script inside the image.  This section describes exactly what the default base image's `/app/setup.sh` script does.
+
+First, it extracts your uploaded tarball into the `/app` directory.  The tarball's contents are all nested under a directory called `bundle`, so this puts your built app into the `/app/bundle` directory.
+
+Next, it figures out which version of Node your app was built with.  If that version isn't already part of the image, it downloads and installs it.  In either case, it sets the `$PATH` environment variable to ensure that the correct version of Node is used for the rest of the build process.
+
+Next, it figures out which version of npm your app was built with, and installs that version of npm.
+
+Next, it runs `npm install --unsafe-perm` inside `/app/bundle/programs/server`.  When building your app, the `meteor` tool includes the contents of most npm packages in the tarball, but if those packages contain binary code, they may need to be rebuilt for the 64-bit Linux server environment, which is what this command does.
+
+Finally, if the scripts `/app/bundle/programs/server/setup.sh` or `/app/bundle/setup.sh` exist, they are executed. (Current versions of Meteor do not make it easy to include these files in your bundle.)
+
+After running all these commands, the Galaxy image builder saves the state of the image to an internal Docker registry.
+
+<h2 id="run">Run time behavior</h2>
+
+When Galaxy runs an app image based on the default base image, it executes a script called `/app/run.sh`.
+
+This script adds the proper version of Node to `$PATH`, just like at [build time](#build).  It also makes the version of Node available in `$NODE_VERSION`.
+
+If the script `/app/bundle/run.sh` exists, then this script is executed with `bash`.  (Current versions of Meteor do not make it easy to include this file in your bundle.)
+
+Otherwise, the script runs `node $GALAXY_NODE_OPTIONS main.js` inside the `/app/bundle` directory. You can set `$GALAXY_NODE_OPTIONS` to a flag or space-separated series of flags [in your settings.json file](/environment-variables.html) if you need fine-grained control over how Node runs your server, such as setting [garbage collection flags](/scaling.html#garbage-collection).

--- a/content/container-environment.md
+++ b/content/container-environment.md
@@ -10,6 +10,34 @@ description: Learn in what environment Galaxy runs your app
 
 Galaxy runs your app in a set of containers using the [Docker](https://www.docker.com/) container platform.
 
+The actual code that is run is determined by the "base image" --- either the [default base image](/base-image-packages.html) or a [custom base image](/custom-base-images.html).
+
+Galaxy runs your app on 64-bit Linux machines in the UTC time zone.
+
+<h2 id="stopping-containers">How containers stop</h2>
+
+When Galaxy wants to shut down your container (because you have deployed a new version, because you are scaling down, because Galaxy is replacing the underlying machine, or other reasons), it first sends the `SIGTERM` signal to your container, waits a grace period of 30 seconds, and then sends the `SIGKILL` signal.  If you'd like to do some cleanup work before your container dies, you can catch the `SIGTERM` signal (eg, with [`process.on('SIGTERM')`](https://nodejs.org/api/process.html#process_signal_events) in Node).  The `SIGKILL` signal cannot be caught; containers receiving this signal immediately die.  You can adjust the grace period on your app's settings page. Galaxy informs your app of how long the grace period will be via the `METEOR_SIGTERM_GRACE_PERIOD_SECONDS` environment variable.  If your app has many users, one thing you may wish to do during this grace period is close incoming connections gradually.  You can use our [`@meteorjs/ddp-graceful-shutdown`](https://www.npmjs.com/package/@meteorjs/ddp-graceful-shutdown) npm package (as described in [this blog post](https://blog.meteor.com/new-in-galaxy-gradual-client-transitions-during-deploys-fa78f4505df6)) to do this easily.
+
+<h2 id="env-vars">Environment variables</h2>
+
+Galaxy runs your app with the following environment variables set:
+
+| Environment variable | Default value | meaning |
+| -------------------- | ------------- | ------- |
+| `APM_*` | Various | Galaxy Pro apps with Meteor APM enabled have several environment variables starting with `APM_` to configure their APM agent. |
+| `GALAXY_APP_ID` | App identifier like `Ss8o4Y6KrvFBKKkqM` | Internal identifier for your app. |
+| `GALAXY_APP_VERSION_ID` | Integer like `123` | The container's app version. |
+| `GALAXY_CONTAINER_ID` | Container ID including app ID, like `Ss8o4Y6KrvFBKKkqM-3n28` | Internal identifier for this container. |
+| `GALAXY_LOGGER` | `system` | For historical reasons, indicates to your container that log collection is handled by Galaxy. |
+| `HTTP_FORWARDED_COUNT` | `1` | Tells your app that it is running behind a proxy. |
+| `KADIRA_OPTIONS_HOSTNAME` | Short container ID, like `3n28` | For historical reasons, used to configure the third-party Kadira service on which Meteor APM is based. |
+| `METEOR_SETTINGS` | A JSON object, set [when you deploy your app](/deploy-guide.html#settings-create) | Available as [`Meteor.settings`](https://docs.meteor.com/api/core.html#Meteor-settings). Galaxy may add fields to your settings object to enable features such as [prerender](/seo.html), and may reformat the JSON object. |
+| `METEOR_SIGTERM_GRACE_PERIOD_SECONDS` | `30` | The length of the [container termination grace period](#stopping-containers). |
+| `PORT` | Integer like `3000` | [Port on which your app should listen](#network-incoming). |
+| `ROOT_URL` | Your app's default hostname, prefixed with `http://` or `https://` depending on whether you use Force HTTPS | Used by [`Meteor.absoluteUrl()`](https://docs.meteor.com/api/core.html#Meteor-absoluteUrl) to generate links. |
+
+You can add your own environment variables and override any of these except for the container-specific ones (`GALAXY_CONTAINER_ID` and `KADIRA_OPTIONS_HOSTNAME`) and `GALAXY_LOGGER` [via your settings.json file](/environment-variables.html).
+
 <h2 id="network">Network environment</h2>
 
 <h3 id="network-incoming">Incoming connections</h3>
@@ -17,14 +45,6 @@ Galaxy runs your app in a set of containers using the [Docker](https://www.docke
 Galaxy runs your app containers in a firewalled network environment.  Only one port is exposed for external connections.  Galaxy tells your app what port to listen on via the `$PORT` environment variable, which contains a number such as `3000`.
 
 Galaxy forwards HTTP connections (port 80) on your app's configured [domains](/custom-domains.html) to the port exposed for external connections. HTTPS connections (port 443) are also forwarded to this port if you've [configured encryption](/encryption.html).  You cannot serve connections on any other ports.
-
-<h3 id="load-balancing">Load Balancing</h3>
-
-New client connections are routed to "least loaded" containers. "Least loaded" is defined as the container with the fewest existing client connections.
-
-If a container grows its memory or CPU usage, the existing client connections won't be re-routed, unless that container fails a health check. Failing a health check happens when that container doesn't respond to HTTP health check pings.
-
-If a container crashes, new users will be routed to a healthy container.
 
 <h3 id="network-outgoing">Outgoing connections and IP whitelisting</h3>
 
@@ -40,3 +60,12 @@ To find the IP addresses you should be using, go to your app's Settings page and
 
 If your software wants you to specify your whitelist as a list of [CIDRs](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) rather than a list of IP addresses, just add the three characters `/32` to the end of each IP address.
 
+<h2 id="load-balancing">Health checking and load balancing</h2>
+
+Galaxy expects that your container will provide an HTTP server listening on the port given in the `$PORT` environment variable. Galaxy expects that the HTTP server will respond to a `GET /` request with a well-formed HTTP response within 5 seconds. (Galaxy currently only validates that the response is a well-formed HTTP response, but it is a good idea to ensure that this response does not have a 5xx status code, as we may refine our definition of "healthy" in the future.)  If your container does not have a functional HTTP server listening on the given port, Galaxy will consider that container to be "unhealthy".
+
+New client connections are routed to "least loaded" healthy containers. "Least loaded" is defined as the container with the fewest existing client connections.
+
+If a container grows its memory or CPU usage, the existing client connections won't be re-routed, unless that container is marked as unhealthy. That is to say: Galaxy currently does not actively rebalance existing clients between healthy containers. If a container crashes or is marked unhealthy, its users will be routed to a healthy container.
+
+If a new container stays unhealthy for 10 minutes, or a container that was once healthy becomes unhealthy and stays in that state for 5 minutes, Galaxy will replace it with a new container. Additionally, Galaxy will wait at least 10 minutes (longer for apps with many containers) for all containers of a newly deployed app version to become healthy before declaring the deploy a success, and will return to the previous active version on failure. You may disable all of the behaviors in this paragraph under "Unhealthy container replacement" on your app's settings page.

--- a/content/custom-base-images.md
+++ b/content/custom-base-images.md
@@ -1,0 +1,54 @@
+---
+title: Custom base images
+order: 17
+description: Learn how to customize your app's environment
+---
+
+Most Galaxy users run their app with the [default base image](/base-image-packages.html).  This provides a basic environment for running most Meteor apps.
+
+For full control over your app's environment, you can provide a custom base image instead.  This allows you to precisely control the set of system packages available to your app, customize exactly what happens when Galaxy builds your app's image at deploy time and when Galaxy runs your app, and even allows you to run non-Meteor software on Galaxy.
+
+A base image is a [Docker](https://www.docker.com/) image.  Base images must live on [Docker Hub](https://hub.docker.com/) and be publicly readable.  (This means they should not contain any secrets.)
+
+You build your base image using a Dockerfile.  You should use the Dockerfile to choose an operating system for your base image (such as `ubuntu:16.04`) and install packages.  You can look at the [source of the Galaxy default base image](https://github.com/meteor/galaxy-images) for inspiration.  The Dockerfile should also add a file called `/app/setup.sh` and specify a command to run with the `CMD` or `ENTRYPOINT` directives.  For more details, see the [Docker documentation](https://docs.docker.com/).
+
+Once you've built your base image and pushed it to Docker Hub, specify it in your settings.json file under `baseImage` inside `galaxy.meteor.com` (next to `env`).  You need to specify both the Docker repository (which generally includes your username) and the tag you want to use.  For example, your settings file may look like:
+
+```
+{
+  "galaxy.meteor.com": {
+    "env": { "MONGO_URL": "mongodb://..." },
+    "baseImage": {
+      "repository": "username/my-galaxy-base-image",
+      "tag": "v23"
+    }
+  }
+}
+```
+
+Docker allows you to push a new image to an existing tag. Currently, if you do this, Galaxy will not rebuild your app until you perform another `meteor deploy`.  We may change this policy in the future.  We recommend that you use a new tag each time your change your base image, and specify that tag rather than a mutable tag like `latest` in your `baseImage` specification.
+
+<h2 id="build">Build time behavior</h2>
+
+When you run `meteor deploy`, your local `meteor` command-line tool builds your app, bundles it into a [tarball](https://en.wikipedia.org/wiki/Tar_(computing%29), and uploads it to Galaxy.
+
+Galaxy then builds a Docker image for your app based on the default base image by running the `/app/setup.sh` script inside the image using `/bin/bash`. Every custom base image must contain `/bin/bash` and `/app/setup.sh`.  (We may relax this requirement in the future to allow `/app/setup.sh` to work with any shell, so you must make sure that `/app/setup.sh` has the executable bit set and that it has a proper [shebang line](https://en.wikipedia.org/wiki/Shebang_(Unix%29).)
+
+Galaxy provides a single argument to your setup script: an URL to your app's tarball.  Note that this URL is not guaranteed to work forever: your setup script should download the tarball during the build phase rather than storing the URL for the run phase.  We suggest you download and expand the tarball with a command like
+
+```
+cd /app && curl -sS "$1" | tar xz -m
+```
+
+(The `-m` flag ignores timestamps from the computer used to run `meteor deploy`; if that computer has clock skew, some build systems can get confused, so it's safer to just set timestamps inside the image builder.)
+
+The script should do whatever other build-time behavior is required, such as invoking `npm install` or other build systems.
+
+
+<h2 id="run">Run time behavior</h2>
+
+To run your app, Galaxy invokes whatever command is specified in your Dockerfile via the [`CMD` or `ENTRYPOINT` directive](https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact).  It does not provide any additional arguments to the command.  Galaxy sets the environment variables documented under [container environment](/container-environment.html).
+
+Your command is expected to run a server that listens on the port specified by the `$PORT` environment variable.  Even if you are using Galaxy to run code that isn't a traditional web server (for example, some sort of helper process for your main app), Galaxy expects to see a functioning web server in order to consider your app to be healthy.  If you choose to deploy software on Galaxy which does not have a web server, you should disable unhealthy container replacement on your app's settings page.  However, we recommend you expose a web server so that you can tell if your container is healthy or not.
+
+Your container continues to run until its specified command completes or Galaxy stops it.

--- a/content/deploy-region.md
+++ b/content/deploy-region.md
@@ -1,6 +1,6 @@
 ---
 title: Regions
-order: 17
+order: 18
 description: Learn how to deploy your app to regions around the world
 ---
 

--- a/content/environment-variables.md
+++ b/content/environment-variables.md
@@ -1,5 +1,5 @@
 ---
-title: Environment variables
+title: Setting environment variables
 order: 12
 description: Learn how to adjust Galaxy environment variables using your app's settings.json file
 ---
@@ -12,9 +12,10 @@ The following environment variable are commonly set for Galaxy apps:
 
 - `MONGO_URL`: If you have any Meteor packages that requires a Mongo database, then this environment variable must be set. See your database provider instructions to determine the correct format and content for the URL. An example format would be `"MONGO_URL": "mongodb://<db_username>:<db_password>@<db_server_host>:<db_server_port>/<db_name>"`
 - `MONGO_OPLOG_URL`: This is an optional environment variable if you are using MongoDB for your application. This is a performance optimization that we recommend for production applications. Read more in our [detailed documentation](https://github.com/meteor/docs/blob/master/long-form/oplog-observe-driver.md#oplogobservedriver-in-production) or in [this useful guide](https://meteorhacks.com/mongodb-oplog-and-meteor/). An example format would be `"MONGO_OPLOG_URL": "mongodb://<oplog_username>:<oplog_password>@<db_server_host>:<db_server_port>/<oplog_db_name>?authSource=admin"`
-- `ROOT_URL`: This is an optional environment variable. If you have any Meteor packages that need to generate a URL, then those packages will use `ROOT_URL` to identify the URL where the app is hosted. The default value for this is the primary hostname that your app is deployed to. This variable hooks up to the Meteor.absoluteUrl() API.
+- `ROOT_URL`: This is an optional environment variable. If you have any Meteor packages that need to generate a URL, then those packages will use `ROOT_URL` to identify the URL where the app is hosted. The default value for this is the primary hostname that your app is deployed to. This variable hooks up to the `Meteor.absoluteUrl()` API.
 - `MAIL_URL`: This is required if you have the `email`  package in your application. In order to send email from the application, the `MAIL_URL` environment variable needs to be set. An example format would be `"MAIL_URL": "smtp://postmaster%40your.mailserver.address.com:password@mailserver.smtp.address.com:587"`
 - `GALAXY_NODE_OPTIONS`: This is for any Node settings that can be controlled at the command line.
+- `USER_LOG_DESTINATION`: This allows you to configure [custom log storage](./logs.html#custom-storage).
 
 If you're using MongoDB, you'll have to configure a database and a user account with rights to access that database with your database provider.
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -24,6 +24,7 @@ sidebar_categories:
     - mongodb
     - container-environment
     - base-image-packages
+    - custom-base-images
     - deploy-region
     - migrate-app
   Setup:

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -1791,13 +1800,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1805,6 +1807,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2660,15 +2669,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -3927,11 +3927,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3941,6 +3936,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -4380,11 +4380,11 @@
       "resolved": "https://registry.npmjs.org/warehouse/-/warehouse-2.2.0.tgz",
       "integrity": "sha1-XQnWSUKZK+Zn2PfIagnCuK6gQGI=",
       "requires": {
+        "JSONStream": "1.3.1",
         "bluebird": "3.5.0",
         "cuid": "1.3.8",
         "graceful-fs": "4.1.11",
         "is-plain-object": "2.0.4",
-        "JSONStream": "1.3.1",
         "lodash": "4.17.4"
       }
     },


### PR DESCRIPTION
This is now ready for release. We needed to:

- [x] Finish rolling out the logger infrastructure changes
- [x] Simplify the default base image to not contain the old logger infrastructure
- [x] Make the base image Docker repositories public
- [x] Make the base image GitHub source repository public
