### PR TITLE
Region consistency (across docs)

### DIFF
--- a/content/custom-domains.md
+++ b/content/custom-domains.md
@@ -4,7 +4,7 @@ order: 20
 description: Learn how to make an application accessible via a custom domain name
 ---
 
-You can specify one or more hostnames for an application. Galaxy will make the app available on those hostnames. These hostnames can be on a custom domain, or can use the Galaxy-provided .meteorapp.com and eu.meteorapp.com domains, for the us-east-1 and eu-west-1 regions, respectively.
+You can specify one or more hostnames for an application. Galaxy will make the app available on those hostnames. These hostnames can be on a custom domain, or can use the Galaxy-provided .meteorapp.com and eu.meteorapp.com domains, for the US East and EU West regions, respectively.
 
 <h2 id="command-line">When first deploying</h2>
 
@@ -22,9 +22,9 @@ If you want to change the primary hostname of your app then deploy a new app at 
 
 Galaxy allows subdomains on .meteorapp.com for use by any app deployed to Galaxy.
 
-For apps deployed to Galaxy's us-east-1 region, deploy to `<custom.subdomain>.meteorapp.com`.
+For apps deployed to Galaxy's US East  region, deploy to `<custom.subdomain>.meteorapp.com`.
 
-For apps deployed to Galaxy's eu-west-1 region, deploy to `<custom.subdomain>.eu.meteorapp.com`.
+For apps deployed to Galaxy's EU West region, deploy to `<custom.subdomain>.eu.meteorapp.com`.
 
 <h2 id="add-domain">Adding additional custom domains</h2>
 

--- a/content/deploy-guide.md
+++ b/content/deploy-guide.md
@@ -78,7 +78,7 @@ For a detailed example of the settings.json file, see [Environment Variables](/e
 
 <h2 id="select-hostname">Select a hostname</h2>
 
-Choose a hostname that the public can use to access your application. You can use a custom domain or you can use the included *.meteorapp.com domain. If you are using the included domain, use <hostname>.meteorapp.com for apps deployed to the us-east-1 region or <hostname>.eu.meteorapp.com for apps deployed to the eu-west-1 region.
+Choose a hostname that the public can use to access your application. You can use a custom domain or you can use the included *.meteorapp.com domain. If you are using the included domain, use <hostname>.meteorapp.com for apps deployed to the US East region or <hostname>.eu.meteorapp.com for apps deployed to the EU West region.
 
 If you have a custom domain name, then you need to point your DNS (in your registrar’s dashboard) to galaxy-ingress.meteor.com. More instructions on DNS configuration can be found [here](/dns.html).
 
@@ -88,9 +88,9 @@ Use the Meteor CLI tool to deploy the application to Galaxy. Make sure that you 
 
 The value of DEPLOY_HOSTNAME will depend on which region you are deploying to:
 
-- To deploy to us-east-1: DEPLOY_HOSTNAME=galaxy.meteor.com
+- To deploy to US East: DEPLOY_HOSTNAME=galaxy.meteor.com
 
-- To deploy to eu-west-1: DEPLOY_HOSTNAME=eu-west-1.galaxy.meteor.com
+- To deploy to EU West: DEPLOY_HOSTNAME=eu-west-1.galaxy.meteor.com
 
 <h3 id="deploy-mac">Mac and Linux</h3>
 
@@ -141,9 +141,9 @@ Once your application is successfully deployed, head on over to your [Galaxy das
 
 Add a domain in your application’s settings and point your DNS to:
 
-- `galaxy-ingress.meteor.com` for applications in the us-east-1 region.
+- `galaxy-ingress.meteor.com` for applications in the US East region.
 
-- `eu-west-1.galaxy-ingress.meteor.com` for applications in the eu-west-1 region.  
+- `eu-west-1.galaxy-ingress.meteor.com` for applications in the EU West region.  
 
 If you are deploying to a root domain (for example mydomain.com), then follow the advanced instructions [here](/dns.html).
 

--- a/content/deploy-quickstart.md
+++ b/content/deploy-quickstart.md
@@ -14,9 +14,9 @@ Before you begin, [configure access to your MongoDB database](/mongodb.html) and
 
 The value of DEPLOY_HOSTNAME will depend on which region you are deploying to:
 
-- To deploy to us-east-1: DEPLOY_HOSTNAME=galaxy.meteor.com
+- To deploy to US East: DEPLOY_HOSTNAME=galaxy.meteor.com
 
-- To deploy to eu-west-1: DEPLOY_HOSTNAME=eu-west-1.galaxy.meteor.com
+- To deploy to EU West: DEPLOY_HOSTNAME=eu-west-1.galaxy.meteor.com
 
 <h3 id="deploy-mac">Mac and Linux</h3>
 
@@ -34,7 +34,7 @@ DEPLOY_HOSTNAME=galaxy.meteor.com meteor deploy [hostname] --settings path-to-se
 
 If you are using Windows, the commands to deploy are slightly different. You need to set the environment variable first, then run the deployment command second (the syntax is the same as everything you'd put for meteor deploy).
 
-The commands will look like this, for the example case of us-east-1:
+The commands will look like this, for the example case of US East:
 
 ```
 $ SET DEPLOY_HOSTNAME=galaxy.meteor.com
@@ -45,9 +45,9 @@ $ meteor deploy [hostname] --settings path-to-settings.json
 
 <h2 id="configure-app">Configure your app</h2>
 
-Once your app is successfully deployed, head on over to the [us-east-1](http://galaxy.meteor.com) dashboard or the [eu-west-1](http://eu-west-1.galaxy.meteor.com) dashboard to configure your app by adding a custom domain name and enabling SSL encryption.
+Once your app is successfully deployed, head on over to the [US East](http://galaxy.meteor.com) dashboard or the [EU West](http://eu-west-1.galaxy.meteor.com) dashboard to configure your app by adding a custom domain name and enabling SSL encryption.
 
-Add a domain in your app’s settings and point your DNS to `galaxy-ingress.meteor.com` for the us-east-1 region, or `eu-west-1.galaxy-ingress.meteor.com` for the eu-west-1 region.
+Add a domain in your app’s settings and point your DNS to `galaxy-ingress.meteor.com` for the US East region, or `eu-west-1.galaxy-ingress.meteor.com` for the EU West region.
 
 <img src="images/email-add-domain.png" style="">
 


### PR DESCRIPTION
Formerly regions were referred to as us-east-1 and eu-west-1. This
commit changes that to US East and EU West, as that's easier to read
on the page and flows better.