### PR TITLE
Update the theme to be consistent with the other Meteor themes.

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -65,9 +65,30 @@ sidebar_categories:
     - support
     - security
 
+# themeing
+favicon: '../images/favicon.png'
+
+logo:
+  nav_mobile: '../images/logo-coralspace-left.svg'
+  url: 'http://www.meteor.com/hosting'
+  title: 'Meteor Galaxy Docs'
+  subtitle: 'Galaxy Docs'
+
+nav_links:
+  'Meteor.com': 'https://www.meteor.com'
+  'Install': 'https://www.meteor.com/install'
+  'Guide': 'http://guide.meteor.com'
+  'Tutorials': 'https://www.meteor.com/tutorials/blaze/creating-an-app'
+  'Docs': 'http://docs.meteor.com'
+  'Forums': 'https://forums.meteor.com/'
+
+social_links:
+  github: 'https://github.com/meteor'
+  twitter: '@meteor'
+
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: http://galaxy-docs.meteor.com/
+url: http://galaxy-guide.meteor.com/
 root: /
 permalink: :year/:month/:day/:title/
 permalink_defaults:

--- a/site/assets/theme-colors.less
+++ b/site/assets/theme-colors.less
@@ -1,0 +1,1 @@
+// Haven't made any changes as we want the default Meteor colors

--- a/site/package.json
+++ b/site/package.json
@@ -7,19 +7,20 @@
   },
   "dependencies": {
     "hexo": "^3.1.0",
-    "hexo-autoprefixer": "^0.1.0",
+    "hexo-autoprefixer": "^1.0.0",
     "hexo-generator-archive": "^0.1.2",
     "hexo-generator-category": "^0.1.2",
-    "hexo-generator-index": "^0.1.2",
-    "hexo-generator-tag": "^0.1.1",
-    "hexo-renderer-ejs": "^0.1.0",
-    "hexo-renderer-jade": "^0.1.0",
-    "hexo-renderer-stylus": "^0.3.0",
+    "hexo-generator-index": "^0.2.0",
+    "hexo-generator-tag": "^0.2.0",
+    "hexo-renderer-ejs": "^0.2.0",
+    "hexo-renderer-jade": "^0.3.0",
+    "hexo-renderer-less": "^0.2.0",
     "hexo-renderer-marked": "^0.2.4",
-    "hexo-server": "^0.1.2"
+    "hexo-renderer-stylus": "^0.3.0",
+    "hexo-server": "^0.2.0"
   },
   "devDependencies": {
-    "hexo-s3-deploy": "^1.0.1"
+    "hexo-s3-deploy": "meteor/hexo-s3-deploy#e36f6d046660040878bb5bedfc8422f526a78be6"
   },
   "scripts": {
     "deploy": "hexo-s3-deploy",


### PR DESCRIPTION
This changes the theme submodule to be the current version of https://github.com/meteor/hexo-theme-meteor/, which the current theme is also based on, but has iterated substantially since.

All existing features should still work properly but I've added the `_config.yml` necessary to properly theme it for the Galaxy Guide (links, logo, etc.).