### PR TITLE
 Fix syntax highlighting in `logs.md`

### DIFF
--- a/content/logs.md
+++ b/content/logs.md
@@ -71,7 +71,7 @@ Elasticsearch has changed some of its APIs in recent versions, so the exact inde
 
 For versions of Elasticsearch earlier than v6, run the following code at your shell (substituting in your Elasticsearch server's credentials and address) to create the index template:
 
-```
+```sh
 curl -X PUT 'https://username:password@your-elasticsearch-server.com/_template/app_logs?pretty' -H 'Content-Type: application/json' -d '
 {
   "template": "app_logs-*",
@@ -120,7 +120,7 @@ curl -X PUT 'https://username:password@your-elasticsearch-server.com/_template/a
 
 For Elasticsearch v6, run the following code at your shell (substituting in your Elasticsearch server's credentials and address) to create the index template:
 
-```
+```sh
 curl -X PUT 'https://username:password@your-elasticsearch-server.com/_template/app_logs?pretty' -H 'Content-Type: application/json' -d '
 {
   "index_patterns": ["app_logs-*"],


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/1312807/36171384-bf07eb32-1102-11e8-8d51-4800595a28f2.png)

After:
![after](https://user-images.githubusercontent.com/1312807/36171385-c12350e6-1102-11e8-95db-c1b2b6eb2c49.png)