### PR TITLE
Change Renovate config from `apollo-docs` to `meteor-docs`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "renovate": {
     "extends": [
-      "apollo-docs"
+      "meteor-docs"
     ]
   }
 }


### PR DESCRIPTION
While these two renovate configuration extensions, `apollo-docs`[0] `meteor-docs`[1] are _very_ similar, they are intentionally different and this was certainly a result of me copying and pasting the wrong configuration.  There is currently one outstanding PR (https://github.com/meteor/galaxy-docs/pull/140) which would have been automatically merged, had I used the right configuration.

[0] https://github.com/apollographql/renovate-config-apollo-docs
[1] https://github.com/meteor/renovate-config-meteor-docs