### PR TITLE
Stop clearing the `docsearch` configuration in `_config.yml` (i.e. Re-enable search).

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,6 @@ title: Galaxy Docs
 subtitle: Galaxy Docs
 apis:
   segment: G21NW9GGR3lY3f37qLk9Ym1fH6EjfJFB
-  docsearch:
 versions:
   - '1'
 github_repo: meteor/galaxy-docs


### PR DESCRIPTION
This property is normally set on a Meteor-wide level by the
`meteor-hexo-config`[0] package, but had previously been getting explicitly
undefined with this empty YAML `docsearch` property.

This should re-enable search on the Galaxy Guide. 🎉 

(See Netlify below to test!)

[0] https://github.com/meteor/meteor-hexo-config

Closes #133