### PR TITLE
Have CircleCI use Node version from .nvmrc, rather than duplicating it.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,4 @@
-machine:
-  node:
-    version: 8
+checkout:
+  post:
+    # Use the node version declared in .nvmrc
+    - nvm install && nvm alias default $(nvm current)


### PR DESCRIPTION
Netlify uses the `.nvmrc` file in order to determine which version of Node
it should use, whereas CircleCI uses a `machine.node.version` attribute in
its YAML configuration.

Renovate bot then comes along and (kindly) updates the `.nvmrc` to the
latest version whenever it can, but doesn't do the same for CircleCI.

By using a post-checkout command on CircleCI, ~it's likely that~ (Edit: Confirmed, see test run) we can avoid this duplication and just maintain a single spot to update the version (plus have more faith in our tests and deployments matching up).