### PR TITLE
change meteorhacks:aggregate into sakulstra:aggregate

### DIFF
--- a/source/apm-make-your-app-faster.md
+++ b/source/apm-make-your-app-faster.md
@@ -75,7 +75,7 @@ Sometimes you'll receive a lot of data for the method and do some calculations i
 Install the following package.
 
 ~~~shell
-meteor add meteorhacks:aggregate
+meteor add sakulstra:aggregate
 ~~~
 
 Use this code.


### PR DESCRIPTION
`meteorhacks:aggregate` seams not maintained anymore and does not work with Meteor 1.7.x. `sakulstra:aggregate` is its maintained fork and works as it should.
See https://github.com/sakulstra/meteor-aggregate#what-the-fork for further details about why the fork has been created and https://github.com/meteorhacks/meteor-aggregate/issues/48#issuecomment-396610701 to see the problem with `meteorhacks:aggregate`